### PR TITLE
Add additional programs

### DIFF
--- a/.config/bootstrap-elementary.sh
+++ b/.config/bootstrap-elementary.sh
@@ -43,6 +43,12 @@ installMerge() {
     apt update && apt -y install sublime-merge
 }
 
+installKubectl() {
+    curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
+    echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" | tee -a /etc/apt/sources.list.d/kubernetes.list
+    apt-get update && apt-get install -y kubectl
+}
+
 updateDock() {
     local plankLaunchers=$HOME/.config/plank/dock1/launchers
     updateWebBrowerDock
@@ -100,6 +106,7 @@ installSpotify
 installChrome
 installMerge
 installAzureCli
+installKubectl
 
 # Add launchers to plank dock for elementary users
 [ $(lsb_release -is) = "elementary" ] && updateDock

--- a/.config/bootstrap-elementary.sh
+++ b/.config/bootstrap-elementary.sh
@@ -101,10 +101,9 @@ programs=$(cat $HOME/.config/programs)
 removePrograms=$(cat $HOME/.config/remove)
 apt -y install $programs && apt -y remove $removePrograms  # Only remove programs when replacements installed successfully
 
-snaps=$(cat $HOME/.config/snaps)
-for snap in $snaps; do
+while read $snap; do
     snap install $snap
-done
+done <$HOME/.config/snaps
 
 getMicrosoftGpgKey # Needed for code and azure cli
 

--- a/.config/bootstrap-elementary.sh
+++ b/.config/bootstrap-elementary.sh
@@ -8,6 +8,8 @@
 installDocker() {
     curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
     add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu bionic stable"
+    sudo curl -L "https://github.com/docker/compose/releases/download/1.23.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+    sudo chmod +x /usr/local/bin/docker-compose
     apt update && apt -y install docker-ce docker-ce-cli containerd.io
 }
 
@@ -84,6 +86,7 @@ installDocker
 installCode
 installSpotify
 installChrome
+installMerge
 
 # Add launchers to plank dock for elementary users
 [ $(lsb_release -is) = "elementary" ] && updateDock

--- a/.config/bootstrap-elementary.sh
+++ b/.config/bootstrap-elementary.sh
@@ -49,6 +49,10 @@ installKubectl() {
     apt-get update && apt-get install -y kubectl
 }
 
+installNvm() {
+    curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.34.0/install.sh | bash
+}
+
 updateDock() {
     local plankLaunchers=$HOME/.config/plank/dock1/launchers
     updateWebBrowerDock
@@ -110,9 +114,7 @@ installChrome
 installMerge
 installAzureCli
 installKubectl
+installNvm
 
 # Add launchers to plank dock for elementary users
 [ $(lsb_release -is) = "elementary" ] && updateDock
-
-# Comment this line out if you do not want to use fish as your default shell
-command -v fish > /dev/null && chsh -s $(which fish)

--- a/.config/bootstrap-elementary.sh
+++ b/.config/bootstrap-elementary.sh
@@ -14,10 +14,14 @@ installDocker() {
 }
 
 installCode() {
-    curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.gpg
-    install -o root -g root -m 644 microsoft.gpg /etc/apt/trusted.gpg.d/
     add-apt-repository "deb [arch=amd64] https://packages.microsoft.com/repos/vscode stable main"
     apt update && apt -y install code
+}
+
+installAzureCli() {
+    echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ bionic main" | \
+        sudo tee /etc/apt/sources.list.d/azure-cli.list
+    apt update && apt -y install azure-cli
 }
 
 installSpotify() {
@@ -71,6 +75,12 @@ removeUnusedProgramLaunchers() {
     rm $plankLaunchers/io.elementary.photos.dockitem
 }
 
+getMicrosoftGpgKey() {
+    curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.gpg
+    install -o root -g root -m 644 microsoft.gpg /etc/apt/trusted.gpg.d/
+    rm microsoft.gpg
+}
+
 apt -y install software-properties-common
 
 ppas=$(cat $HOME/.config/ppas)
@@ -81,12 +91,15 @@ programs=$(cat $HOME/.config/programs)
 removePrograms=$(cat $HOME/.config/remove)
 apt -y install $programs && apt -y remove $removePrograms  # Only remove programs when replacements installed successfully
 
+getMicrosoftGpgKey # Needed for code and azure cli
+
 # Adhoc installs; comment out lines for programs you do not want
 installDocker
 installCode
 installSpotify
 installChrome
 installMerge
+installAzureCli
 
 # Add launchers to plank dock for elementary users
 [ $(lsb_release -is) = "elementary" ] && updateDock

--- a/.config/bootstrap-elementary.sh
+++ b/.config/bootstrap-elementary.sh
@@ -102,7 +102,9 @@ removePrograms=$(cat $HOME/.config/remove)
 apt -y install $programs && apt -y remove $removePrograms  # Only remove programs when replacements installed successfully
 
 snaps=$(cat $HOME/.config/snaps)
-snap install $snaps
+for snap in $snaps; do
+    snap install $snap
+done
 
 getMicrosoftGpgKey # Needed for code and azure cli
 

--- a/.config/bootstrap-elementary.sh
+++ b/.config/bootstrap-elementary.sh
@@ -11,6 +11,8 @@ installDocker() {
     sudo curl -L "https://github.com/docker/compose/releases/download/1.23.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
     sudo chmod +x /usr/local/bin/docker-compose
     apt update && apt -y install docker-ce docker-ce-cli containerd.io
+    groupadd docker
+    usermod -aG docker cam # Update this to be the user who started command
 }
 
 installCode() {

--- a/.config/bootstrap-elementary.sh
+++ b/.config/bootstrap-elementary.sh
@@ -97,6 +97,9 @@ programs=$(cat $HOME/.config/programs)
 removePrograms=$(cat $HOME/.config/remove)
 apt -y install $programs && apt -y remove $removePrograms  # Only remove programs when replacements installed successfully
 
+snaps=$(cat $HOME/.config/snaps)
+snap install $snaps
+
 getMicrosoftGpgKey # Needed for code and azure cli
 
 # Adhoc installs; comment out lines for programs you do not want

--- a/.config/fish/config.fish
+++ b/.config/fish/config.fish
@@ -3,6 +3,7 @@ fish_vi_key_bindings
 if status --is-login
 	# Path updates
 	set -x PATH $PATH ~/bin
+	set -x PATH /usr/local/bin $PATH
 
 	# Variables
 	set -x NOTES_HOME $HOME/notes

--- a/.config/programs
+++ b/.config/programs
@@ -14,3 +14,4 @@ com.github.donadigo.eddy
 com.github.artemanufrij.screencast
 youtube-dl
 virtualbox
+snapd

--- a/.config/programs
+++ b/.config/programs
@@ -13,3 +13,4 @@ com.github.lainsce.notejot
 com.github.donadigo.eddy
 com.github.artemanufrij.screencast
 youtube-dl
+virtualbox

--- a/.config/snaps
+++ b/.config/snaps
@@ -1,2 +1,3 @@
 slack --classic
 --edge teams-for-linux
+powershell --classic

--- a/.config/snaps
+++ b/.config/snaps
@@ -1,3 +1,4 @@
 slack --classic
 --edge teams-for-linux
 powershell --classic
+dotnet --classic

--- a/.config/snaps
+++ b/.config/snaps
@@ -1,0 +1,2 @@
+slack --classic
+--edge teams-for-linux


### PR DESCRIPTION
This PR adds the programs listed in #9. Some of the new programs are installed as snaps, which will be the preferred way of installing non-obvious programs going forward. #13 is tracking moving some programs to snaps as well. A discovery made during this process is that `nvm` is not compatible with the fish shell, so for now I'll fall back to using bash and investigating if any work can be done to simply wrap `nvm` calls in fish. 